### PR TITLE
Add cube color and orientation settings

### DIFF
--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:settings_ui/settings_ui.dart';
 import 'package:flutter_colorpicker/flutter_colorpicker.dart';
+import 'package:cube_guide/utils/constants.dart';
 
 class SettingsPage extends StatefulWidget {
   const SettingsPage({Key? key}) : super(key: key);
@@ -50,7 +51,16 @@ class _SettingsPageState extends State<SettingsPage> {
                   SettingsTile.navigation(
                     leading: const Icon(Icons.filter_center_focus),
                     title: const Text('Front side'),
-                    value: Text(controller.frontSide.value),
+                    valueWidget: Container(
+                      width: 24,
+                      height: 24,
+                      decoration: BoxDecoration(
+                        color: _hexToColor(
+                          controller.colors[controller.frontSide.value]!,
+                        ),
+                        border: Border.all(color: Colors.black26),
+                      ),
+                    ),
                     onPressed: (context) {
                       _showSidePicker(context, true, controller);
                     },
@@ -58,7 +68,16 @@ class _SettingsPageState extends State<SettingsPage> {
                   SettingsTile.navigation(
                     leading: const Icon(Icons.height),
                     title: const Text('Top side'),
-                    value: Text(controller.topSide.value),
+                    valueWidget: Container(
+                      width: 24,
+                      height: 24,
+                      decoration: BoxDecoration(
+                        color: _hexToColor(
+                          controller.colors[controller.topSide.value]!,
+                        ),
+                        border: Border.all(color: Colors.black26),
+                      ),
+                    ),
                     onPressed: (context) {
                       _showSidePicker(context, false, controller);
                     },
@@ -159,7 +178,12 @@ class _SettingsPageState extends State<SettingsPage> {
 
   void _showSidePicker(
       BuildContext context, bool isFront, AppController controller) {
-    String selected = isFront ? controller.frontSide.value : controller.topSide.value;
+    String selected =
+        isFront ? controller.frontSide.value : controller.topSide.value;
+    final other = isFront ? controller.topSide.value : controller.frontSide.value;
+    final banned = {other, oppositeSides[other]};
+    final choices =
+        ['W', 'Y', 'R', 'O', 'G', 'B'].where((c) => !banned.contains(c)).toList();
     showDialog(
       context: context,
       builder: (context) {
@@ -169,12 +193,26 @@ class _SettingsPageState extends State<SettingsPage> {
               title: Text(isFront ? 'Select front side' : 'Select top side'),
               content: Column(
                 mainAxisSize: MainAxisSize.min,
-                children: ['W', 'Y', 'R', 'O', 'G', 'B']
+                children: choices
                     .map(
                       (side) => RadioListTile<String>(
-                        title: Text(side),
                         value: side,
                         groupValue: selected,
+                        title: Row(
+                          children: [
+                            Container(
+                              width: 20,
+                              height: 20,
+                              decoration: BoxDecoration(
+                                color: _hexToColor(controller.colors[side]!),
+                                shape: BoxShape.circle,
+                                border: Border.all(color: Colors.black26),
+                              ),
+                            ),
+                            const SizedBox(width: 8),
+                            Text(side),
+                          ],
+                        ),
                         onChanged: (value) {
                           setState(() {
                             selected = value!;

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -49,26 +49,9 @@ class _SettingsPageState extends State<SettingsPage> {
                 title: const Text('Cube orientation'),
                 tiles: <SettingsTile>[
                   SettingsTile.navigation(
-                    leading: const Icon(Icons.filter_center_focus),
-                    title: const Text('Front side'),
-                    valueWidget: Container(
-                      width: 24,
-                      height: 24,
-                      decoration: BoxDecoration(
-                        color: _hexToColor(
-                          controller.colors[controller.frontSide.value]!,
-                        ),
-                        border: Border.all(color: Colors.black26),
-                      ),
-                    ),
-                    onPressed: (context) {
-                      _showSidePicker(context, true, controller);
-                    },
-                  ),
-                  SettingsTile.navigation(
                     leading: const Icon(Icons.height),
                     title: const Text('Top side'),
-                    valueWidget: Container(
+                    value: Container(
                       width: 24,
                       height: 24,
                       decoration: BoxDecoration(
@@ -80,6 +63,23 @@ class _SettingsPageState extends State<SettingsPage> {
                     ),
                     onPressed: (context) {
                       _showSidePicker(context, false, controller);
+                    },
+                  ),
+                  SettingsTile.navigation(
+                    leading: const Icon(Icons.filter_center_focus),
+                    title: const Text('Front side'),
+                    value: Container(
+                      width: 24,
+                      height: 24,
+                      decoration: BoxDecoration(
+                        color: _hexToColor(
+                          controller.colors[controller.frontSide.value]!,
+                        ),
+                        border: Border.all(color: Colors.black26),
+                      ),
+                    ),
+                    onPressed: (context) {
+                      _showSidePicker(context, true, controller);
                     },
                   ),
                 ],

--- a/lib/utils/app_controller.dart
+++ b/lib/utils/app_controller.dart
@@ -7,6 +7,8 @@ class AppController extends GetxController {
 
   var isGrid = false.obs;
   var numberOfFormulas = 1.obs;
+  var frontSide = 'B'.obs;
+  var topSide = 'Y'.obs;
 
   var colors =
       <String, String>{
@@ -28,6 +30,8 @@ class AppController extends GetxController {
     super.onInit();
     isGrid.value = box.read(prefsIsGridKey) ?? false;
     numberOfFormulas.value = box.read(prefsNumberOfFormulasKey) ?? 1;
+    frontSide.value = box.read(prefsFrontSideKey) ?? 'B';
+    topSide.value = box.read(prefsTopSideKey) ?? 'Y';
 
     colors.value = {
       'W': box.read(prefsColorWhiteKey) ?? '#ffffff',
@@ -55,6 +59,16 @@ class AppController extends GetxController {
   void setNumberOfFormulas(int value) {
     numberOfFormulas.value = value;
     box.write(prefsNumberOfFormulasKey, numberOfFormulas.value);
+  }
+
+  void setFrontSide(String value) {
+    frontSide.value = value;
+    box.write(prefsFrontSideKey, value);
+  }
+
+  void setTopSide(String value) {
+    topSide.value = value;
+    box.write(prefsTopSideKey, value);
   }
 
   void setColor(String key, String value) {

--- a/lib/utils/constants.dart
+++ b/lib/utils/constants.dart
@@ -25,3 +25,13 @@ const Map<String, String> oppositeSides = {
   'R': 'O',
   'O': 'R',
 };
+
+/// 3D vectors representing cube sides used for orientation math.
+const Map<String, List<int>> colorVectors = {
+  'Y': [0, 1, 0],
+  'W': [0, -1, 0],
+  'B': [0, 0, 1],
+  'G': [0, 0, -1],
+  'R': [1, 0, 0],
+  'O': [-1, 0, 0],
+};

--- a/lib/utils/constants.dart
+++ b/lib/utils/constants.dart
@@ -13,3 +13,5 @@ const String prefsColorOrangeKey = 'color_orange';
 const String prefsColorGreenKey = 'color_green';
 const String prefsColorBlueKey = 'color_blue';
 const String prefsColorGreyKey = 'color_grey';
+const String prefsFrontSideKey = 'front_side';
+const String prefsTopSideKey = 'top_side';

--- a/lib/utils/constants.dart
+++ b/lib/utils/constants.dart
@@ -15,3 +15,13 @@ const String prefsColorBlueKey = 'color_blue';
 const String prefsColorGreyKey = 'color_grey';
 const String prefsFrontSideKey = 'front_side';
 const String prefsTopSideKey = 'top_side';
+
+/// Map of cube colors to their opposite sides.
+const Map<String, String> oppositeSides = {
+  'W': 'Y',
+  'Y': 'W',
+  'B': 'G',
+  'G': 'B',
+  'R': 'O',
+  'O': 'R',
+};

--- a/lib/widgets/cube_svg.dart
+++ b/lib/widgets/cube_svg.dart
@@ -65,7 +65,8 @@ class CubeSvg {
     }
 
     return Obx(() {
-      var colorsArray = notation.split('').map((e) => c.colors[e]).toList();
+      var colorsArray =
+          notation.split('').map((e) => c.rotatedColors[e]).toList();
       var out = svg.format(colorsArray);
 
       return SvgPicture.string(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
   introduction_screen: ^3.1.17
   cupertino_icons: ^1.0.8
   settings_ui: ^2.0.2
+  flutter_colorpicker: ^1.0.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- allow color customization per cube side via flutter_colorpicker
- let users choose front and top sides
- store new settings in `AppController`
- add flutter_colorpicker dependency

## Testing
- `flutter format --set-exit-if-changed .` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test --coverage` *(fails: command not found)*
- `flutter build apk --release --no-tree-shake-icons` *(fails: command not found)*
- `flutter build ios --no-codesign` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844aa7fd14483339a21f78b4e971d7f